### PR TITLE
Prevent modifications to input data during array checks.

### DIFF
--- a/toleranceinterval/checks.py
+++ b/toleranceinterval/checks.py
@@ -35,5 +35,6 @@ def assert_2d_sort(x):
         x = x.reshape(1, -1)
     elif x.ndim > 2:
         raise ValueError('x can not be more than 2 dimensions')
-    x.sort()
+    # Prevent modifications to input data by copying x before sorting.
+    x.copy().sort()
     return x


### PR DESCRIPTION
assert_2d_sort function was modifying its inputs during the sort call. We should make this sort happen on a copy of the data so we don't produce side effects.

It turns out that numpy.array.reshape sometimes produces a view and is not guaranteed to make a copy, hence the need to create an explicit copy prior to sorting.